### PR TITLE
Fix session initialisation

### DIFF
--- a/brawlstats/core.py
+++ b/brawlstats/core.py
@@ -63,7 +63,7 @@ class Client:
 
     def __init__(self, token, **options):
         self.is_async = options.get('is_async', False)
-        self.session = options.get('session', aiohttp.ClientSession() if self.is_async else requests.Session())
+        self.session = options.get('session') or (aiohttp.ClientSession() if self.is_async else requests.Session())
         self.timeout = options.get('timeout', 10)
         self.api = API(options.get('url'))
         self.headers = {


### PR DESCRIPTION
If you provide your own session, one gets initialized anyways since you passed the expression as a parameter in `dict.get()`. This leads to unclosed `aiohttp.ClientSession` warnings.

# Type of PR
- [x] Bug Fix