### PR TITLE
fix: ricochet is now named rico

### DIFF
--- a/brawlstats/utils.py
+++ b/brawlstats/utils.py
@@ -18,7 +18,7 @@ class API:
             'shelly', 'nita', 'colt', 'bull', 'jessie',  # league reward 0-500
             'brock', 'dynamike', 'bo',                   # league reward 1000+
             'el primo', 'barley', 'poco', 'rosa',        # rare
-            'ricochet', 'penny', 'darryl', 'carl',       # super rare
+            'rico', 'penny', 'darryl', 'carl',       # super rare
             'frank', 'pam', 'piper',                     # epic
             'mortis', 'tara', 'gene',                    # mythic
             'spike', 'crow', 'leon'                      # legendary


### PR DESCRIPTION
# Changes Description
Ricochet is now named rico, and brawlstats won't allow users to get the leaderboard of rico.

# Type of PR
- [X] Bug Fix
- [ ] Feature Addition

# Checklist
- [ ] Docstrings added ([NumpyDoc](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard))
- [ ] If necessary, add to the documentation files
- [ ] Tox checked
