### PR TITLE
Fix get_leaderboard for a certain brawler

### DIFF
--- a/brawlstats/brawlapi/core.py
+++ b/brawlstats/brawlapi/core.py
@@ -261,7 +261,7 @@ class Client:
 
         url = '{}/{}?count={}&region={}'.format(self.api.LEADERBOARD, lb_type, limit, region)
         if lb_type == 'brawlers':
-            url = '{}/players?count={}&brawlers={}&region={}'.format(self.api.LEADERBOARD, limit, lb_type, region)
+            url = '{}/players?count={}&brawlers={}&region={}'.format(self.api.LEADERBOARD, limit, brawler, region)
 
         return self._get_model(url, model=Leaderboard)
 


### PR DESCRIPTION
This fixes the issue of get_leaderboard with brawler argument not working

# Changes Description
This fixes the issue of get_leaderboard with brawler argument not working

# Type of PR
- [ X] Bug Fix
- [ ] Feature Addition

# Checklist
- [ ] Docstrings added ([NumpyDoc](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard))
- [ ] If necessary, add to the documentation files
- [ ] Tox checked
