### PR TITLE
Rewrote tests

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,2 @@
+include requirements.txt
+include requirements-dev.txt

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,6 +1,6 @@
-python-dotenv
-flake8
 asynctest
+flake8
 pytest
+pytest-asyncio
+python-dotenv
 tox-travis
-pluggy>=0.12.0,<1.0.0

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,5 +1,6 @@
 asynctest
 flake8
+pluggy>=0.12.0,<1.0.0
 pytest
 pytest-asyncio
 python-dotenv

--- a/tests/test_async.py
+++ b/tests/test_async.py
@@ -36,9 +36,14 @@ class TestAsyncClient(asynctest.TestCase):
         self.assertIsInstance(club, brawlstats.Club)
         self.assertEqual(club.tag, self.CLUB_TAG)
 
-        await self.assertAsyncRaises(brawlstats.NotFoundError, self.client.get_player('2PPPPPPP'))
-        await self.assertAsyncRaises(brawlstats.NotFoundError, self.client.get_player('P'))
-        await self.assertAsyncRaises(brawlstats.NotFoundError, self.client.get_player('AAA'))
+        with self.assertRaises(brawlstats.NotFoundError):
+            await self.client.get_player('2PPPPPPP')
+
+        with self.assertRaises(brawlstats.NotFoundError):
+            await self.client.get_player('P')
+
+        with self.assertRaises(brawlstats.NotFoundError):
+            await self.client.get_player('AAA')
 
     async def test_get_battle_logs(self):
         battle_logs = await self.client.get_battle_logs(self.PLAYER_TAG)
@@ -53,9 +58,14 @@ class TestAsyncClient(asynctest.TestCase):
         self.assertIsInstance(club_members, brawlstats.Members)
         self.assertIn(self.PLAYER_TAG, [x.tag for x in club_members])
 
-        await self.assertAsyncRaises(brawlstats.NotFoundError, self.client.get_club('8GGGGGGG'))
-        await self.assertAsyncRaises(brawlstats.NotFoundError, self.client.get_club('P'))
-        await self.assertAsyncRaises(brawlstats.NotFoundError, self.client.get_club('AAA'))
+        with self.assertRaises(brawlstats.NotFoundError):
+            await self.client.get_club('8GGGGGGG')
+
+        with self.assertRaises(brawlstats.NotFoundError):
+            await self.client.get_club('P')
+
+        with self.assertRaises(brawlstats.NotFoundError):
+            await self.client.get_club('AAA')
 
     async def test_get_club_members(self):
         club_members = await self.client.get_club_members(self.CLUB_TAG)

--- a/tests/test_async.py
+++ b/tests/test_async.py
@@ -47,6 +47,10 @@ class TestAsyncClient(asynctest.TestCase):
         self.assertIsInstance(club, brawlstats.Club)
         self.assertEqual(club.tag, self.CLUB_TAG)
 
+        club_members = await club.get_members()
+        self.assertIsInstance(club_members, brawlstats.Members)
+        self.assertIn(self.PLAYER_TAG, [x.tag for x in club_members])
+
         await self.assertAsyncRaises(brawlstats.NotFoundError, self.client.get_club('8GGGGGGG'))
 
     async def test_get_club_members(self):

--- a/tests/test_async.py
+++ b/tests/test_async.py
@@ -37,6 +37,8 @@ class TestAsyncClient(asynctest.TestCase):
         self.assertEqual(club.tag, self.CLUB_TAG)
 
         await self.assertAsyncRaises(brawlstats.NotFoundError, self.client.get_player('2PPPPPPP'))
+        await self.assertAsyncRaises(brawlstats.NotFoundError, self.client.get_player('P'))
+        await self.assertAsyncRaises(brawlstats.NotFoundError, self.client.get_player('AAA'))
 
     async def test_get_battle_logs(self):
         battle_logs = await self.client.get_battle_logs(self.PLAYER_TAG)
@@ -52,6 +54,8 @@ class TestAsyncClient(asynctest.TestCase):
         self.assertIn(self.PLAYER_TAG, [x.tag for x in club_members])
 
         await self.assertAsyncRaises(brawlstats.NotFoundError, self.client.get_club('8GGGGGGG'))
+        await self.assertAsyncRaises(brawlstats.NotFoundError, self.client.get_club('P'))
+        await self.assertAsyncRaises(brawlstats.NotFoundError, self.client.get_club('AAA'))
 
     async def test_get_club_members(self):
         club_members = await self.client.get_club_members(self.CLUB_TAG)

--- a/tests/test_async.py
+++ b/tests/test_async.py
@@ -1,108 +1,104 @@
-import asynctest
-import asyncio
 import os
 
+import aiohttp
+import asynctest
 import brawlstats
-from brawlstats.models import BattleLog, Club, Constants, Members, Ranking
-from dotenv import load_dotenv, find_dotenv
+import pytest
+from dotenv import load_dotenv
 
-load_dotenv(find_dotenv('.env'))
-
-TOKEN = os.getenv('token')
-URL = os.getenv('base_url')
+pytestmark = pytest.mark.asyncio
 
 
 class TestAsyncClient(asynctest.TestCase):
-    """Tests all methods in the asynchronous client that
-    uses the `aiohttp` module in `brawlstats`
-    """
+    use_default_loop = True
+
+    PLAYER_TAG = '#GGJVJLU2'
+    CLUB_TAG = '#QCCQCGV'
+
     async def setUp(self):
-        self.player_tag = '#GGJVJLU2'
-        self.club_tag = '#QCGV8PG'
+        load_dotenv()
+
+        session = aiohttp.ClientSession(loop=self.loop)
+
         self.client = brawlstats.Client(
-            TOKEN,
+            os.getenv('token'),
+            base_url=os.getenv('base_url'),
             is_async=True,
-            base_url=URL,
-            timeout=30
+            loop=self.loop,
+            session=session
         )
 
-    async def tearDown(self):
-        await asyncio.sleep(1)
-        await self.client.close()
-
     async def test_get_player(self):
-        player = await self.client.get_player(self.player_tag)
-        self.assertEqual(player.tag, self.player_tag)
+        player = await self.client.get_player(self.PLAYER_TAG)
+        self.assertIsInstance(player, brawlstats.Player)
+        self.assertEqual(player.tag, self.PLAYER_TAG)
 
         club = await player.get_club()
-        self.assertIsInstance(club, Club)
+        self.assertIsInstance(club, brawlstats.Club)
+        self.assertEqual(club.tag, self.CLUB_TAG)
+
+        await self.assertAsyncRaises(brawlstats.NotFoundError, self.client.get_player('2PPPPPPP'))
+
+    async def test_get_battle_logs(self):
+        battle_logs = await self.client.get_battle_logs(self.PLAYER_TAG)
+        self.assertIsInstance(battle_logs, brawlstats.BattleLog)
 
     async def test_get_club(self):
-        club = await self.client.get_club(self.club_tag)
-        self.assertEqual(club.tag, self.club_tag)
+        club = await self.client.get_club(self.CLUB_TAG)
+        self.assertIsInstance(club, brawlstats.Club)
+        self.assertEqual(club.tag, self.CLUB_TAG)
 
-        members = await club.get_members()
-        self.assertIsInstance(members, Members)
+        await self.assertAsyncRaises(brawlstats.NotFoundError, self.client.get_club('8GGGGGGG'))
 
     async def test_get_club_members(self):
-        members = await self.client.get_club_members(self.club_tag)
-        self.assertIsInstance(members, Members)
+        club_members = await self.client.get_club_members(self.CLUB_TAG)
+        self.assertIsInstance(club_members, brawlstats.Members)
+        self.assertIn(self.PLAYER_TAG, [x.tag for x in club_members])
 
-    async def test_get_rankings_player(self):
-        rankings = await self.client.get_rankings(ranking='players')
-        self.assertIsInstance(rankings, Ranking)
-        region = await self.client.get_rankings(ranking='players', region='us')
-        self.assertIsInstance(region, Ranking)
+        await self.assertAsyncRaises(brawlstats.NotFoundError, self.client.get_club_members('8GGGGGGG'))
 
-    async def test_get_rankings_club(self):
-        rankings = await self.client.get_rankings(ranking='clubs')
-        self.assertIsInstance(rankings, Ranking)
-        limit = await self.client.get_rankings(ranking='clubs', limit=100)
-        self.assertTrue(len(limit) == 100)
+    async def test_get_rankings(self):
+        player_ranking = await self.client.get_rankings(ranking='players')
+        self.assertIsInstance(player_ranking, brawlstats.Ranking)
 
-    async def test_get_rankings_brawler(self):
-        rankings = await self.client.get_rankings(ranking='brawlers', brawler='shelly')
-        self.assertIsInstance(rankings, Ranking)
-        rankings = await self.client.get_rankings(ranking='brawlers', brawler=16000000)
-        self.assertIsInstance(rankings, Ranking)
+        us_player_ranking = await self.client.get_rankings(ranking='players', region='US', limit=1)
+        self.assertIsInstance(us_player_ranking, brawlstats.Ranking)
+        self.assertTrue(len(us_player_ranking) == 1)
+
+        club_ranking = await self.client.get_rankings(ranking='clubs')
+        self.assertIsInstance(club_ranking, brawlstats.Ranking)
+
+        us_club_ranking = await self.client.get_rankings(ranking='clubs', region='US', limit=1)
+        self.assertIsInstance(us_club_ranking, brawlstats.Ranking)
+        self.assertTrue(len(us_club_ranking) == 1)
+
+        brawler_ranking = await self.client.get_rankings(ranking='brawlers', brawler='Shelly')
+        self.assertIsInstance(brawler_ranking, brawlstats.Ranking)
+
+        us_brawler_ranking = await self.client.get_rankings(ranking='brawlers', brawler=16000000, region='US', limit=1)
+        self.assertIsInstance(us_brawler_ranking, brawlstats.Ranking)
+        self.assertTrue(len(us_brawler_ranking) == 1)
+
+        with self.assertRaises(ValueError):
+            await self.client.get_rankings(ranking='people')
+
+        with self.assertRaises(ValueError):
+            await self.client.get_rankings(ranking='people', limit=0)
+
+        with self.assertRaises(ValueError):
+            await self.client.get_rankings(ranking='brawlers', brawler='SharpBit')
 
     async def test_get_constants(self):
-        default = await self.client.get_constants()
-        self.assertIsInstance(default, Constants)
+        constants = await self.client.get_constants()
+        self.assertIsInstance(constants, brawlstats.Constants)
+
         maps = await self.client.get_constants('maps')
-        self.assertIsInstance(maps, Constants)
+        self.assertIsInstance(maps, brawlstats.Constants)
 
-        async def request():
-            await self.get_constants(invalid_key)
-        invalid_key = 'invalid'
-        self.assertAsyncRaises(KeyError, request)
+        await self.assertAsyncRaises(KeyError, self.client.get_constants('invalid'))
 
-    async def test_battle_logs(self):
-        logs = await self.client.get_battle_logs(self.player_tag)
-        self.assertIsInstance(logs, BattleLog)
-
-    async def test_invalid_tag(self):
-        async def request():
-            await self.client.get_player(invalid_tag)
-        invalid_tag = 'P'
-        self.assertAsyncRaises(brawlstats.NotFoundError, request)
-        invalid_tag = 'AAA'
-        self.assertAsyncRaises(brawlstats.NotFoundError, request)
-        invalid_tag = '2PPPPPPP'
-        self.assertAsyncRaises(brawlstats.NotFoundError, request)
-
-    async def test_invalid_rankings(self):
-        async def request():
-            await self.client.get_rankings(ranking=invalid_ranking, limit=invalid_limit)
-        invalid_ranking = 'test'
-        invalid_limit = 200
-        self.assertAsyncRaises(ValueError, request)
-        invalid_ranking = 'players'
-        invalid_limit = 201
-        self.assertAsyncRaises(ValueError, request)
-        invalid_ranking = 'players'
-        invalid_limit = -5
-        self.assertAsyncRaises(ValueError, request)
+    async def asyncTearDown(self):
+        await self.client.close()
 
 
 if __name__ == '__main__':

--- a/tests/test_async.py
+++ b/tests/test_async.py
@@ -114,8 +114,8 @@ class TestAsyncClient(asynctest.TestCase):
 
         await self.assertAsyncRaises(KeyError, self.client.get_constants('invalid'))
 
-    def tearDown(self):
-        self.client.close()
+    async def asyncTearDown(self):
+        await self.client.close()
 
 
 if __name__ == '__main__':

--- a/tests/test_async.py
+++ b/tests/test_async.py
@@ -24,7 +24,6 @@ class TestAsyncClient(asynctest.TestCase):
             os.getenv('token'),
             base_url=os.getenv('base_url'),
             is_async=True,
-            loop=self.loop,
             session=session
         )
 
@@ -97,8 +96,8 @@ class TestAsyncClient(asynctest.TestCase):
 
         await self.assertAsyncRaises(KeyError, self.client.get_constants('invalid'))
 
-    async def asyncTearDown(self):
-        await self.client.close()
+    def tearDown(self):
+        self.client.close()
 
 
 if __name__ == '__main__':

--- a/tests/test_blocking.py
+++ b/tests/test_blocking.py
@@ -28,6 +28,8 @@ class TestBlockingClient(unittest.TestCase):
         self.assertEqual(club.tag, self.CLUB_TAG)
 
         self.assertRaises(brawlstats.NotFoundError, self.client.get_player, '2PPPPPPP')
+        self.assertRaises(brawlstats.NotFoundError, self.client.get_player, 'P')
+        self.assertRaises(brawlstats.NotFoundError, self.client.get_player, 'AAA')
 
     def test_get_battle_logs(self):
         battle_logs = self.client.get_battle_logs(self.PLAYER_TAG)
@@ -43,6 +45,8 @@ class TestBlockingClient(unittest.TestCase):
         self.assertIn(self.PLAYER_TAG, [x.tag for x in club_members])
 
         self.assertRaises(brawlstats.NotFoundError, self.client.get_club, '8GGGGGGG')
+        self.assertRaises(brawlstats.NotFoundError, self.client.get_club, 'P')
+        self.assertRaises(brawlstats.NotFoundError, self.client.get_club, 'AAA')
 
     def test_get_club_members(self):
         club_members = self.client.get_club_members(self.CLUB_TAG)

--- a/tests/test_blocking.py
+++ b/tests/test_blocking.py
@@ -38,6 +38,10 @@ class TestBlockingClient(unittest.TestCase):
         self.assertIsInstance(club, brawlstats.Club)
         self.assertEqual(club.tag, self.CLUB_TAG)
 
+        club_members = club.get_members()
+        self.assertIsInstance(club_members, brawlstats.Members)
+        self.assertIn(self.PLAYER_TAG, [x.tag for x in club_members])
+
         self.assertRaises(brawlstats.NotFoundError, self.client.get_club, '8GGGGGGG')
 
     def test_get_club_members(self):

--- a/tests/test_blocking.py
+++ b/tests/test_blocking.py
@@ -1,104 +1,89 @@
-import unittest
 import os
-import time
+import unittest
 
 import brawlstats
-from brawlstats.models import BattleLog, Club, Constants, Members, Ranking
-from dotenv import load_dotenv, find_dotenv
-
-load_dotenv(find_dotenv('.env'))
-
-TOKEN = os.getenv('token')
-URL = os.getenv('base_url')
+from dotenv import load_dotenv
 
 
 class TestBlockingClient(unittest.TestCase):
-    """Tests all methods in the blocking client that
-    uses the `requests` module in `brawlstats`
-    """
+
+    PLAYER_TAG = '#GGJVJLU2'
+    CLUB_TAG = '#QCCQCGV'
+
     def setUp(self):
-        self.player_tag = '#GGJVJLU2'
-        self.club_tag = '#QCGV8PG'
+        load_dotenv()
+
         self.client = brawlstats.Client(
-            TOKEN,
-            is_async=False,
-            base_url=URL,
-            timeout=30
+            os.getenv('token'),
+            base_url=os.getenv('base_url')
         )
 
-    def tearDown(self):
-        time.sleep(1)
-        self.client.close()
-
     def test_get_player(self):
-        player = self.client.get_player(self.player_tag)
-        self.assertEqual(player.tag, self.player_tag)
+        player = self.client.get_player(self.PLAYER_TAG)
+        self.assertIsInstance(player, brawlstats.Player)
+        self.assertEqual(player.tag, self.PLAYER_TAG)
 
         club = player.get_club()
-        self.assertIsInstance(club, Club)
+        self.assertIsInstance(club, brawlstats.Club)
+        self.assertEqual(club.tag, self.CLUB_TAG)
+
+        self.assertRaises(brawlstats.NotFoundError, self.client.get_player, '2PPPPPPP')
+
+    def test_get_battle_logs(self):
+        battle_logs = self.client.get_battle_logs(self.PLAYER_TAG)
+        self.assertIsInstance(battle_logs, brawlstats.BattleLog)
 
     def test_get_club(self):
-        club = self.client.get_club(self.club_tag)
-        self.assertEqual(club.tag, self.club_tag)
+        club = self.client.get_club(self.CLUB_TAG)
+        self.assertIsInstance(club, brawlstats.Club)
+        self.assertEqual(club.tag, self.CLUB_TAG)
 
-        members = club.get_members()
-        self.assertIsInstance(members, Members)
+        self.assertRaises(brawlstats.NotFoundError, self.client.get_club, '8GGGGGGG')
 
     def test_get_club_members(self):
-        members = self.client.get_club_members(self.club_tag)
-        self.assertIsInstance(members, Members)
+        club_members = self.client.get_club_members(self.CLUB_TAG)
+        self.assertIsInstance(club_members, brawlstats.Members)
+        self.assertIn(self.PLAYER_TAG, [x.tag for x in club_members])
 
-    def test_get_rankings_player(self):
-        rankings = self.client.get_rankings(ranking='players')
-        self.assertIsInstance(rankings, Ranking)
-        region = self.client.get_rankings(ranking='players', region='us')
-        self.assertIsInstance(region, Ranking)
+        self.assertRaises(brawlstats.NotFoundError, self.client.get_club_members, '8GGGGGGG')
 
-    def test_get_rankings_club(self):
-        rankings = self.client.get_rankings(ranking='clubs')
-        self.assertIsInstance(rankings, Ranking)
-        limit = self.client.get_rankings(ranking='clubs', limit=100)
-        self.assertTrue(len(limit) == 100)
+    def test_get_rankings(self):
+        player_ranking = self.client.get_rankings(ranking='players')
+        self.assertIsInstance(player_ranking, brawlstats.Ranking)
 
-    def test_get_rankings_brawler(self):
-        rankings = self.client.get_rankings(ranking='brawlers', brawler='shelly')
-        self.assertIsInstance(rankings, Ranking)
-        rankings = self.client.get_rankings(ranking='brawlers', brawler=16000000)
-        self.assertIsInstance(rankings, Ranking)
+        us_player_ranking = self.client.get_rankings(ranking='players', region='US', limit=1)
+        self.assertIsInstance(us_player_ranking, brawlstats.Ranking)
+        self.assertTrue(len(us_player_ranking) == 1)
+
+        self.assertRaises(ValueError, self.client.get_rankings, ranking='people')
+        self.assertRaises(ValueError, self.client.get_rankings, ranking='people', limit=0)
+        self.assertRaises(ValueError, self.client.get_rankings, ranking='brawlers', brawler='SharpBit')
+
+        club_ranking = self.client.get_rankings(ranking='clubs')
+        self.assertIsInstance(club_ranking, brawlstats.Ranking)
+
+        us_club_ranking = self.client.get_rankings(ranking='clubs', region='US', limit=1)
+        self.assertIsInstance(us_club_ranking, brawlstats.Ranking)
+        self.assertTrue(len(us_club_ranking) == 1)
+
+        brawler_ranking = self.client.get_rankings(ranking='brawlers', brawler='Shelly')
+        self.assertIsInstance(brawler_ranking, brawlstats.Ranking)
+
+        us_brawler_ranking = self.client.get_rankings(ranking='brawlers', brawler=16000000, region='US', limit=1)
+        self.assertIsInstance(us_brawler_ranking, brawlstats.Ranking)
+        self.assertTrue(len(us_brawler_ranking) == 1)
 
     def test_get_constants(self):
-        default = self.client.get_constants()
-        self.assertIsInstance(default, Constants)
+        constants = self.client.get_constants()
+        self.assertIsInstance(constants, brawlstats.Constants)
+
         maps = self.client.get_constants('maps')
-        self.assertIsInstance(maps, Constants)
-        get_constants = self.client.get_constants
-        invalid_key = 'invalid'
-        self.assertRaises(KeyError, get_constants, invalid_key)
+        self.assertIsInstance(maps, brawlstats.Constants)
 
-    def test_battle_logs(self):
-        logs = self.client.get_battle_logs(self.player_tag)
-        self.assertIsInstance(logs, BattleLog)
+        self.assertRaises(KeyError, self.client.get_constants, 'invalid')
 
-    def test_invalid_tag(self):
-        get_player = self.client.get_player
-        invalid_tag = 'P'
-        self.assertRaises(brawlstats.NotFoundError, get_player, invalid_tag)
-        invalid_tag = 'AAA'
-        self.assertRaises(brawlstats.NotFoundError, get_player, invalid_tag)
-        invalid_tag = '2PPPPPPP'
-        self.assertRaises(brawlstats.NotFoundError, get_player, invalid_tag)
-
-    def test_invalid_rankings(self):
-        get_rankings = self.client.get_rankings
-        invalid_ranking = 'test'
-        invalid_limit = 200
-        self.assertRaises(ValueError, get_rankings, ranking=invalid_ranking, limit=invalid_limit)
-        invalid_ranking = 'players'
-        invalid_limit = 201
-        self.assertRaises(ValueError, get_rankings, ranking=invalid_ranking, limit=invalid_limit)
-        invalid_ranking = 'players'
-        invalid_limit = -5
-        self.assertRaises(ValueError, get_rankings, ranking=invalid_ranking, limit=invalid_limit)
+    def tearDown(self):
+        self.client.close()
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
# Rewrote tests

This PR adds some rewritten tests to `./tests`. They've been tested on Python version 3.8.2, using tox version 3.14.6.

The added `MANIFEST.in` file should make sure both requirements files are able to be detected in the virtual env.

Lastly, I removed `pluggy` from the `requirements-dev.txt` file, as tox uses it as dependency already.