### PR TITLE
Delete get_constants, fix get_rankings and supplement get_brawlers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# manual testing/debugging files
+some.py
+
 # VSCode settings
 .vscode/
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,26 @@
 All notable changes to this project will be documented in this file.
 
 
+## [Unnoun yet] - 6/28/20
+### Added
+- `find_brawler` function added to utils
+- `find` function added to `Brawlers`
+- `MyBox` and `MyBoxList` to also control the behavior of subclasses, such as brawler in brawlers, etc.
+### Changed
+- `Api.BRAWLERS_URL` -> `Api.BRAWLERS`
+- examples now use get_brawlers
+### Fixed
+- now `get_rankings` works, and handles all cases (earlier errors could occur, for example, if you did not enter `brawler` if `ranking == "brawlers"`)
+### Deleted
+- `get_constants`
+-`Api.CONSTANTS`
+- old `Api.BRAWLERS`
+- loading in `Api` `Api.BRAWLERS`
+- class `Constants`
+- `if model == Constants` and its body from `_aget_model` and `_get_model`
+- `key` argument from `_aget_model` and `_get_model`
+(as unnecessary, get_brawlers replaces this)
+
 ## [Unnoun yet] - 6/27/20
 ### Added
 - `get_brawlers` function to get available brawlers

--- a/brawlstats/core.py
+++ b/brawlstats/core.py
@@ -10,7 +10,7 @@ from cachetools import TTLCache
 
 from .errors import Forbidden, NotFoundError, RateLimitError, ServerError, UnexpectedError
 from .models import BattleLog, Brawlers, Club, Members, Player, Ranking
-from .utils import API, bstag, typecasted, find_brawler
+from .utils import API, bstag, typecasted
 
 log = logging.getLogger(__name__)
 
@@ -273,7 +273,6 @@ class Client:
                 if isinstance(brawler, int):
                     pattern = "id"
                 elif isinstance(brawler, str):
-                    brawler = brawler.upper()
                     pattern = "name"
                 else:
                     raise TypeError('Invalid `brawler` type, must be str or int')

--- a/brawlstats/models.py
+++ b/brawlstats/models.py
@@ -5,6 +5,24 @@ from .utils import bstag, find_brawler
 __all__ = ['Player', 'Club', 'Members', 'Ranking', 'BattleLog', 'Brawlers']
 
 
+# for child classes
+class MyBox(Box):
+    def __getattr__(self, attr):
+        try:
+            return super().__getattr__(attr)
+        except AttributeError:
+            return None  # users can use an if statement rather than try/except to find a missing attribute
+
+
+# for child classes
+class MyBoxList(BoxList):
+    def __getattr__(self, attr):
+        try:
+            return super().__getattr__(attr)
+        except AttributeError:
+            return None  # users can use an if statement rather than try/except to find a missing attribute
+
+
 class BaseBox:
     def __init__(self, client, data):
         self.client = client
@@ -12,7 +30,7 @@ class BaseBox:
 
     def from_data(self, data):
         self.raw_data = data
-        self._boxed_data = Box(data, camel_killer_box=True)
+        self._boxed_data = MyBox(data, camel_killer_box=True)
         return self
 
     def __getattr__(self, attr):
@@ -35,7 +53,7 @@ class BaseBoxList(BaseBox):
     def from_data(self, data):
         data = data['items']
         self.raw_data = data
-        self._boxed_data = BoxList(data, camel_killer_box=True)
+        self._boxed_data = MyBoxList(data, box_class=MyBox, camel_killer_box=True)
         return self
 
     def __len__(self):
@@ -128,16 +146,18 @@ class Brawlers(BaseBoxList):
 
     def find(self, pattern, match):
         """
-        Find brawler containing template
+        Find first match brawler containing template
 
         Parameters
         ----------
-        pattern: any python instance, usually str or int
+        pattern: Any, usually str or int
             `match` value to find in brawlers
 
-        match: any python instance, usually str or int
+        match: Any, usually str or int
             key by which the search will be performed
 
         Returns brawler object
         """
+        if pattern == "name" and isinstance(match, str):
+            match = match.upper()
         return find_brawler(self, pattern, match)

--- a/brawlstats/models.py
+++ b/brawlstats/models.py
@@ -1,8 +1,8 @@
 from box import Box, BoxList
-from .utils import bstag
+from .utils import bstag, find_brawler
 
 
-__all__ = ['Player', 'Club', 'Members', 'Ranking', 'BattleLog', 'Constants', 'Brawlers']
+__all__ = ['Player', 'Club', 'Members', 'Ranking', 'BattleLog', 'Brawlers']
 
 
 class BaseBox:
@@ -115,13 +115,6 @@ class BattleLog(BaseBoxList):
     pass
 
 
-class Constants(BaseBox):
-    """
-    Returns some Brawl Stars constants.
-    """
-    pass
-
-
 class Brawlers(BaseBoxList):
     """
     Returns list of available brawlers and information about them.
@@ -132,3 +125,19 @@ class Brawlers(BaseBoxList):
 
     def __str__(self):
         return 'Here {} brawlers'.format(len(self))
+
+    def find(self, pattern, match):
+        """
+        Find brawler containing template
+
+        Parameters
+        ----------
+        pattern: any python instance, usually str or int
+            `match` value to find in brawlers
+
+        match: any python instance, usually str or int
+            key by which the search will be performed
+
+        Returns brawler object
+        """
+        return find_brawler(self, pattern, match)

--- a/brawlstats/utils.py
+++ b/brawlstats/utils.py
@@ -1,8 +1,6 @@
 import inspect
-import json
 import os
 import re
-import urllib.request
 from datetime import datetime
 from functools import wraps
 
@@ -15,30 +13,12 @@ class API:
         self.PROFILE = self.BASE + '/players'
         self.CLUB = self.BASE + '/clubs'
         self.RANKINGS = self.BASE + '/rankings'
-        self.CONSTANTS = 'https://fourjr.herokuapp.com/bs/constants'
-        self.BRAWLERS_URL = self.BASE + "/brawlers"
+        self.BRAWLERS = self.BASE + "/brawlers"
 
         # Get package version from __init__.py
         path = os.path.dirname(__file__)
         with open(os.path.join(path, '__init__.py')) as f:
             self.VERSION = re.search(r'^__version__ = [\'"]([^\'"]*)[\'"]', f.read(), re.MULTILINE).group(1)
-
-        # Get current brawlers and their IDs
-        try:
-            resp = urllib.request.urlopen(self.CONSTANTS + '/characters').read()
-            if isinstance(resp, bytes):
-                resp = resp.decode('utf-8')
-            data = json.loads(resp)
-        except (TypeError, urllib.error.HTTPError, urllib.error.URLError):
-            self.BRAWLERS = {}
-        else:
-            if data:
-                self.BRAWLERS = {
-                    b['tID'].lower(): int(str(b['scId'])[:2] + '0' + str(b['scId'])[2:])
-                    for b in data if b['tID']
-                }
-            else:
-                self.BRAWLERS = {}
 
 
 def bstag(tag):
@@ -111,3 +91,26 @@ def typecasted(func):
                     new_kwargs[nk] = nv
         return func(*new_args, **new_kwargs)
     return wrapper
+
+
+def find_brawler(brawlers, pattern, match):
+    """
+    Find brawler containing template
+
+    Parameters
+    ----------
+    brawlers: Brawlers
+        Brawlers instance
+
+    pattern: any python instance, usually str or int
+        `match` value to find in brawlers
+
+    match: any python instance, usually str or int
+        key by which the search will be performed
+
+    Returns brawler object
+    """
+    for brawler in brawlers:
+        if brawler.get(pattern) == match:
+            return brawler
+    return None  # returns explicitly

--- a/brawlstats/utils.py
+++ b/brawlstats/utils.py
@@ -95,17 +95,17 @@ def typecasted(func):
 
 def find_brawler(brawlers, pattern, match):
     """
-    Find brawler containing template
+    Find first match brawler containing template
 
     Parameters
     ----------
     brawlers: Brawlers
         Brawlers instance
 
-    pattern: any python instance, usually str or int
+    pattern: Any, usually str or int
         `match` value to find in brawlers
 
-    match: any python instance, usually str or int
+    match: Any, usually str or int
         key by which the search will be performed
 
     Returns brawler object

--- a/examples/async.py
+++ b/examples/async.py
@@ -11,6 +11,9 @@ async def main():
     print(player.trophies)  # access attributes using dot.notation
     print(player.solo_victories)  # use snake_case instead of camelCase
 
+    battles = await client.get_battle_logs('GGJVJLU2')
+    print(battles[0].battle.mode)
+
     club = await player.get_club()
     print(club.tag)
     members = await club.get_members()  # members sorted by trophies
@@ -33,8 +36,20 @@ async def main():
     for player in ranking:
         print(player.name, player.rank)
 
-    battles = await client.get_battle_logs('GGJVJLU2')
-    print(battles[0].battle.mode)
+    # get all brawlers and info about them
+    brawlers = await client.get_brawlers()
+    print(brawlers, "->", len(brawlers))
+    for brawler in brawlers[:5]:  # prints top 5 brawlers
+        print(brawler.name)
+
+    # find blrawler by name
+    shelly = brawlers.find("name", "shelly")
+    print(shelly.id)
+
+    # find brawler by id
+    spike = brawlers.find("id", 16000005)
+    print(spike.gadgets)
+
 
 # run the async loop
 loop = asyncio.get_event_loop()

--- a/examples/sync.py
+++ b/examples/sync.py
@@ -8,14 +8,17 @@ player = client.get_profile('GGJVJLU2')
 print(player.trophies)  # access attributes using dot.notation
 print(player.solo_victories)  # use snake_case instead of camelCase
 
+battles = client.get_battle_logs('GGJVJLU2')
+print(battles[0].battle.mode)
+
 club = player.get_club()
 print(club.tag)
 members = club.get_members()  # members sorted by trophies
 best_players = members[:5]  # gets best 5 players
 for player in best_players:
-    print(player.name, player.trophies)  # prints name and trophies
+    print(player.name, player.trophies)
 
-# gets top 5 players in the world
+# get top 5 players in the world
 ranking = client.get_rankings(ranking='players', limit=5)
 for player in ranking:
     print(player.name, player.rank)
@@ -30,5 +33,16 @@ ranking = client.get_rankings(
 for player in ranking:
     print(player.name, player.rank)
 
-battles = client.get_battle_logs('GGJVJLU2')
-print(battles[0].battle.mode)
+# get all brawlers and info about them
+brawlers = client.get_brawlers()
+print(brawlers, "->", len(brawlers))
+for brawler in brawlers[:5]:  # prints top 5 brawlers
+    print(brawler.name)
+
+# find blrawler by name
+shelly = brawlers.find("name", "shelly")
+print("shelly:", shelly.id)
+
+# find brawler by id
+spike = brawlers.find("id", 16000005)
+print("spike`s gadgets:", spike.gadgets)

--- a/tests/test_async.py
+++ b/tests/test_async.py
@@ -99,23 +99,26 @@ class TestAsyncClient(asynctest.TestCase):
             await self.client.get_rankings(ranking='people')
 
         with self.assertRaises(ValueError):
-            await self.client.get_rankings(ranking='people', limit=0)
+            await self.client.get_rankings(ranking='players', limit=0)
+
+        with self.assertRaises(ValueError):
+            await self.client.get_rankings(ranking='players', limit=201)
+
+        with self.assertRaises(ValueError):
+            await self.client.get_rankings(ranking='brawlers')
 
         with self.assertRaises(ValueError):
             await self.client.get_rankings(ranking='brawlers', brawler='SharpBit')
 
-    async def test_get_constants(self):
-        constants = await self.client.get_constants()
-        self.assertIsInstance(constants, brawlstats.Constants)
-
-        maps = await self.client.get_constants('maps')
-        self.assertIsInstance(maps, brawlstats.Constants)
-
-        await self.assertAsyncRaises(KeyError, self.client.get_constants('invalid'))
+        with self.assertRaises(TypeError):
+            await self.client.get_rankings(ranking='brawlers', brawler=5.5)
 
     async def test_get_brawlers(self):
         brawlers = await self.client.get_brawlers()
         self.assertIsInstance(brawlers, brawlstats.Brawlers)
+
+        self.assertTrue(brawlers.find("a", 0) is None)
+        self.assertTrue(brawlers.find("id", 16000000).name == 'SHELLY')
 
     async def asyncTearDown(self):
         await self.client.close()

--- a/tests/test_blocking.py
+++ b/tests/test_blocking.py
@@ -64,10 +64,6 @@ class TestBlockingClient(unittest.TestCase):
         self.assertIsInstance(us_player_ranking, brawlstats.Ranking)
         self.assertTrue(len(us_player_ranking) == 1)
 
-        self.assertRaises(ValueError, self.client.get_rankings, ranking='people')
-        self.assertRaises(ValueError, self.client.get_rankings, ranking='people', limit=0)
-        self.assertRaises(ValueError, self.client.get_rankings, ranking='brawlers', brawler='SharpBit')
-
         club_ranking = self.client.get_rankings(ranking='clubs')
         self.assertIsInstance(club_ranking, brawlstats.Ranking)
 
@@ -82,18 +78,20 @@ class TestBlockingClient(unittest.TestCase):
         self.assertIsInstance(us_brawler_ranking, brawlstats.Ranking)
         self.assertTrue(len(us_brawler_ranking) == 1)
 
-    def test_get_constants(self):
-        constants = self.client.get_constants()
-        self.assertIsInstance(constants, brawlstats.Constants)
+        self.assertRaises(ValueError, self.client.get_rankings, ranking='people')
+        self.assertRaises(ValueError, self.client.get_rankings, ranking='players', limit=0)
+        self.assertRaises(ValueError, self.client.get_rankings, ranking='players', limit=201)
+        self.assertRaises(ValueError, self.client.get_rankings, ranking='brawlers')
+        self.assertRaises(ValueError, self.client.get_rankings, ranking='brawlers', brawler='SharpBit')
+        self.assertRaises(ValueError, self.client.get_rankings, ranking='brawlers', brawler=5.5)
 
-        maps = self.client.get_constants('maps')
-        self.assertIsInstance(maps, brawlstats.Constants)
-
-        self.assertRaises(KeyError, self.client.get_constants, 'invalid')
-
-    def test_get_brawlers(self):
+    async def test_get_brawlers(self):
         brawlers = self.client.get_brawlers()
         self.assertIsInstance(brawlers, brawlstats.Brawlers)
+
+        self.assertTrue(brawlers.find("a", 0) is None)
+        self.assertTrue(brawlers.find("id", 555) is None)
+        self.assertTrue(brawlers.find("id", 16000000).name == 'SHELLY')
 
     def tearDown(self):
         self.client.close()

--- a/tox.ini
+++ b/tox.ini
@@ -4,13 +4,13 @@ exclude = __init__.py,.tox
 ignore = E252,E302,E731,W605
 
 [tox]
-envlist = py35,py36,py37,py38
+envlist = py35,py36,py37
 
 [testenv]
 changedir = tests
 deps = -r{toxinidir}/requirements-dev.txt
 sitepackages = true
-whitelist_externals = flake8,pytest
+whitelist_externals = pytest
 commands =
     flake8
     pytest

--- a/tox.ini
+++ b/tox.ini
@@ -6,7 +6,7 @@ ignore = E252,E302,E731,W605
 [tox]
 envlist = py35,py36,py37,py38
 
-[env]
+[testenv]
 changedir = tests
 deps = -r{toxinidir}/requirements-dev.txt
 sitepackages = true


### PR DESCRIPTION
### Added
- `find_brawler` function added to utils
- `find` function added to `Brawlers`
- `MyBox` and `MyBoxList` to also control the behavior of subclasses, such as brawler in brawlers, etc.
### Changed
- `Api.BRAWLERS_URL` -> `Api.BRAWLERS`
- examples now use get_brawlers
### Fixed
- now `get_rankings` works, and handles all cases (earlier errors could occur, for example, if you did not enter `brawler` if `ranking == "brawlers"`)
### Deleted
- `get_constants`
- `Api.CONSTANTS`
- old `Api.BRAWLERS`
- loading in `Api` `Api.BRAWLERS`
- class `Constants`
- `if model == Constants` and its body from `_aget_model` and `_get_model`
- `key` argument from `_aget_model` and `_get_model`
(as unnecessary, get_brawlers replaces this)

# Checklist
- [yes] Docstrings added ([NumpyDoc](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard))
- [yes] If necessary, add to the documentation files
- [yes] Tox checked
