### PR TITLE
rework the tox so that it uses packages correctly, then just add py3.…

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,18 +1,15 @@
 [flake8]
 max-line-length=120
-exclude = __init__.py,.tox
+exclude = __init__.py
 ignore = E252,E302,E731,W605
 
 [tox]
-envlist = py35,py36,py37
+envlist = py35,py36,py37,py38
 
 [testenv]
-changedir = tests
 deps = -r{toxinidir}/requirements-dev.txt
-sitepackages = true
-whitelist_externals = pytest
 commands =
-    flake8
+    flake8 tests
     pytest
 passenv =
     token


### PR DESCRIPTION
…8 to the envlist

# Changes Description
- change of incorrect configuration tox, now everything works correctly.
- adding py3.8 to envlist

# Type of PR
- [x] Bug Fix
- [x] Feature Addition

# Checklist
- [ ] Docstrings added ([NumpyDoc](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard))
- [ ] If necessary, add to the documentation files
- [x] Tox checked
