### PR TITLE
misc fixes

### DIFF
--- a/brawlstats/models.py
+++ b/brawlstats/models.py
@@ -94,7 +94,12 @@ class Player(BaseBox):
             A list of the members in a club, or None if the player is not in a club.
         """
         if not self.club:
+            if self.client.is_async:
+                async def wrapper():
+                    return None
+                return wrapper()
             return None
+
         url = '{}/{}'.format(self.client.api.CLUB, bstag(self.club.tag))
         return self.client._get_model(url, model=Club)
 

--- a/brawlstats/utils.py
+++ b/brawlstats/utils.py
@@ -44,14 +44,14 @@ def bstag(tag):
     return tag
 
 
-def get_datetime(timestamp: str, unix: bool=True) -> Union[int, datetime.datetime]:
+def get_datetime(timestamp: str, unix: bool=True) -> Union[int, datetime]:
     """Converts a %Y%m%dT%H%M%S.%fZ to a UNIX timestamp or a datetime.datetime object
 
     Parameters
     ----------
     timestamp : str
-        A timestamp in the %Y-%m-%dT%H:%M:%S.%fZ format, usually returned by the API
-        in the ``created_time`` field for example (eg. 2018-07-18T14:59:06.000Z)
+        A timestamp in the %Y%%dT%H%M%S.%fZ format, usually returned by the API in the
+        ``battleTime`` field in battle log responses - e.g., 20200925T184431.000Z
     unix : bool, optional
         Whether to return a POSIX timestamp (seconds since epoch) or not, by default True
 
@@ -60,11 +60,12 @@ def get_datetime(timestamp: str, unix: bool=True) -> Union[int, datetime.datetim
     Union[int, datetime.datetime]
         If unix=True it will return int, otherwise datetime.datetime
     """
-    time = datetime.strptime(timestamp, '%Y-%m-%dT%H:%M:%S.%fZ')
+    time = datetime.strptime(timestamp, '%Y%m%dT%H%M%S.%fZ')
+
     if unix:
         return int(time.timestamp())
-    else:
-        return time
+
+    return time
 
 
 def nothing(value):

--- a/brawlstats/utils.py
+++ b/brawlstats/utils.py
@@ -50,7 +50,7 @@ def get_datetime(timestamp: str, unix: bool=True) -> Union[int, datetime]:
     Parameters
     ----------
     timestamp : str
-        A timestamp in the %Y%%dT%H%M%S.%fZ format, usually returned by the API in the
+        A timestamp in the %Y%m%dT%H%M%S.%fZ format, usually returned by the API in the
         ``battleTime`` field in battle log responses - e.g., 20200925T184431.000Z
     unix : bool, optional
         Whether to return a POSIX timestamp (seconds since epoch) or not, by default True


### PR DESCRIPTION
# Changes Description
Using `await player.get_club()` would result in a TypeError when the user isn't part of any club, as you can't await None. This PR fixes that by returning an awaitable function - if the client is asyncronously used - that resolves to None.

The `brawlstats.utils.get_datetime` function seemed to use the wrong string format - probably because it's Star List API legacy code. There would also be a SyntaxError regarding the type annotation, which I've also fixed.
# Type of PR
- [x] Bug Fix
- [ ] Feature Addition

# Checklist
- [x] Docstrings added ([NumpyDoc](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard))
- [ ] ~~If necessary, add to the documentation files~~
- [ ] Tox checked
